### PR TITLE
`compute.summary.stats`

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -1,5 +1,5 @@
 compute.summary.stats <- function(chr, subset, FUN, file.path, save = FALSE, chunkSize, nCores, verbose = FALSE, buffer.verbose = FALSE, stat.name, recompute = FALSE) {
-  if (save && file.exists(file.path) && !recompute) {
+  if (file.exists(file.path) && !recompute) {
     if (verbose) cat(paste0("File ", file.path, " exists. Computation skipped.\n"))
     sum.stats <- readRDS(file.path)
   } else {


### PR DESCRIPTION
When reading precomputed files for `compute.summary.stats`, I think we don't need to check for the `save` option.
It is possible that one runs the precomputation with `save=T` and resume the computation with `save=F`